### PR TITLE
HTML5Locator 原型的 constructor 应指回 HTML5Locator

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@
      * @returns {string}
      */
     function parseParams(params) {
-        let res = '';
+        var res = '';
 
         for (var key in params) {
             if (Object.hasOwnProperty.call(params, key)) {
@@ -857,7 +857,7 @@
         parseURL: parseURL,
         parseParams: parseParams,
 
-        version: '1.2.4'
+        version: '1.2.3'
     };
 
     // For AMD

--- a/index.js
+++ b/index.js
@@ -690,6 +690,7 @@
     };
 
     Router.prototype.attachCmpt = function (routeItem, e) {
+        var me = this;
         var component = new routeItem.Component();
         component.data.set('route', e);
         if (typeof component.route === 'function') {
@@ -716,6 +717,13 @@
             component: component,
             id: routeItem.id
         });
+
+        // component handler 同时存在
+        if (typeof routeItem.handler === 'function') {
+            setTimeout(function () {
+                routeItem.handler.call(me, e);
+            })
+        }
     };
 
     /**

--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@
     }
 
     HTML5Locator.prototype = new EventTarget();
-    HTML5Locator.prototype.constructor = HashLocator;
+    HTML5Locator.prototype.constructor = HTML5Locator;
 
     /**
      * 开始监听 url 变化

--- a/index.js
+++ b/index.js
@@ -679,6 +679,9 @@
             component.route();
         }
 
+        // 在 san 组件实例中注入 router 路由实例，实现 this.$router.push('/a/b/c'); 这样的功能
+        component['$router'] = this;
+
         var target = routeItem.target;
         var targetEl = elementSelector(target);
 

--- a/index.js
+++ b/index.js
@@ -517,6 +517,10 @@
         options = options || {};
         var mode = options.mode || 'hash';
 
+        if (mode === 'html5' && !HTML5Locator.isSupport) {
+            throw new Error('[SAN-ROUTER ERROR] Your navigator doesn\'t supports HTML5!');
+        }
+
         this.routes = [];
         this.routeAlives = [];
         this.listeners = [];

--- a/index.js
+++ b/index.js
@@ -87,6 +87,23 @@
     }
 
     /**
+     * 解析js对象为location.query形式的字符串
+     * @param {Obejct} params
+     * @returns {string}
+     */
+    function parseParams(params) {
+        let res = '';
+
+        for (var key in params) {
+            if (Object.hasOwnProperty.call(params, key)) {
+                res += key + '=' + encodeURIComponent(params[key]) + '&';
+            }
+        }
+
+        return res ? ('?' + res).slice(0, -1) : '';
+    }
+
+    /**
      * 将 URL 中相对路径部分展开
      *
      * @param {string} source 要展开的url
@@ -752,24 +769,25 @@
      * @param {Object|string} req 更换路由请求
      */
 
-    Router.prototype.push = function (req) {
-        var link = '';
+    Router.prototype.push = function (request, data) {
+        var path = '';
         var params = {};
 
-        switch (typeof req) {
+        switch (typeof request) {
             case 'object':
-                link = req.path || link;
-                params = req.params || params;
+                path = request.path || path;
+                params = request.params || params;
                 break;
             case 'string':
-                link = req;
+                path = request;
+                params = data;
                 break;
             default:
                 break;
         }
 
-        if (!link) return;
-        this.locator.redirect(link.replace(/^#/, ''), { params: params });
+        if (!path) return;
+        this.locator.redirect(path.replace(/^#/, '') + parseParams(params));
     }
 
     var router = new Router();

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@
 
         for (var key in params) {
             if (Object.hasOwnProperty.call(params, key)) {
-                res += key + '=' + encodeURIComponent(params[key]) + '&';
+                res += key + '=' + (params[key] ? encodeURIComponent(params[key]) : '') + '&';
             }
         }
 
@@ -696,7 +696,8 @@
             component.route();
         }
 
-        // 在 san 组件实例中注入 router 路由实例，实现 this.$router.push('/a/b/c'); 这样的功能
+        // 在 san 组件实例中注入 router 路由实例，因此可以直接拿到当前路由实例
+        // 并且实现 this.$router.push('/a/b/c'); 这样的功能，更符合习惯且更简洁
         component['$router'] = this;
 
         var target = routeItem.target;
@@ -765,8 +766,10 @@
     };
 
     /**
-     * 编程式路由函数，间接使用 redirect 重定向
-     * @param {Object|string} req 更换路由请求
+     * 编程式路由函数，间接使用 redirect 重定向，避免直接使用 内部对象locator
+     *
+     * @param {Object|string} request 路由参数，对象或者字符串
+     * @param {Obejct} data 需要传递的 query 参数对象
      */
 
     Router.prototype.push = function (request, data) {
@@ -786,6 +789,7 @@
                 break;
         }
 
+        // 空路由、空对象不处理
         if (!path) return;
         this.locator.redirect(path.replace(/^#/, '') + parseParams(params));
     }
@@ -851,8 +855,9 @@
         HTML5Locator: HTML5Locator,
         resolveURL: resolveURL,
         parseURL: parseURL,
+        parseParams: parseParams,
 
-        version: '1.2.3'
+        version: '1.2.4'
     };
 
     // For AMD

--- a/index.js
+++ b/index.js
@@ -744,6 +744,31 @@
         return this;
     };
 
+    /**
+     * 编程式路由函数，间接使用 redirect 重定向
+     * @param {Object|string} req 更换路由请求
+     */
+
+    Router.prototype.push = function (req) {
+        var link = '';
+        var params = {};
+
+        switch (typeof req) {
+            case 'object':
+                link = req.path || link;
+                params = req.params || params;
+                break;
+            case 'string':
+                link = req;
+                break;
+            default:
+                break;
+        }
+
+        if (!link) return;
+        this.locator.redirect(link.replace(/^#/, ''), { params: params });
+    }
+
     var router = new Router();
 
     var main = {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "san-router",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Router for San",
   "scripts": {
+    "pretest": "http-server ./ &",
+    "test": "open http://127.0.0.1:8080/test",
     "build": "rm -rf dist && mkdir dist && uglifyjs index.js -mco dist/san-router.js"
   },
   "devDependencies": {
+    "http-server": "^0.12.3",
+    "jasmine-core": "^2.99.1",
     "san": "^3.4.2",
-    "uglify-js": "^2.7.5",
-    "jasmine-core": "^2.99.0"
+    "uglify-js": "^2.7.5"
   },
   "main": "index.js",
   "unpkg": "dist/san-router",
@@ -16,7 +19,6 @@
     "src",
     "dist"
   ],
-  "dependencies": {},
   "author": "otakustay",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "san-router",
-  "version": "1.2.4",
+  "version": "1.2.3",
   "description": "Router for San",
   "scripts": {
     "pretest": "http-server ./ &",

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,6 @@
 
 </head>
 <body>
-    <div id="main" style="position:absolute"></div>
+    <div id="main" style="position:absolute;top:80px"></div>
 </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ var HashLocator = sanRouter.HashLocator;
 var HTML5Locator = sanRouter.HTML5Locator;
 
 var parseURL = sanRouter.parseURL;
+var parseParams = sanRouter.parseParams;
 
 
 describe('parseURL', function () {
@@ -792,7 +793,278 @@ describe('Synthesis', function () {
             done();
         }
     });
-
-
 });
 
+// new feature
+describe('test this.$router in San component using hash', function() {
+
+    it('test this.$router exits', function(done) {
+        var App = san.defineComponent({
+            template: '<div>history / something for nothing.</div>'
+        })
+
+        router.setMode('hash');
+
+        router.add({
+            rule: '/router/hash',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            location.hash = '/router/hash'
+        })
+
+        setTimeout(function () {
+            expect(router.routeAlives).toBeDefined();
+            expect(router.routeAlives[0]).toBeDefined();
+            expect(router.routeAlives[0].component).toBeDefined();
+            expect(router.routeAlives[0].component.$router).toBeDefined();
+            router.stop();
+            done();
+        }, 200);
+    })
+})
+
+describe('test this.$router in San component using html5 history', function() {
+
+    it('test this.$router exits', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            router.locator.redirect('/router/html5');
+        })
+
+        setTimeout(function () {
+            expect(router.routeAlives).toBeDefined();
+            expect(router.routeAlives[0]).toBeDefined();
+            expect(router.routeAlives[0].component).toBeDefined();
+            expect(router.routeAlives[0].component.$router).toBeDefined();
+
+            router.stop();
+            done();
+        }, 200);
+    })
+})
+
+describe('test this.$router.push with hash mode', function() {
+
+    it('test this.$router.push with object params', function(done) {
+        var App = san.defineComponent({
+            template: '<div>something for nothing.</div>'
+        })
+
+        router.setMode('hash');
+
+        router.add({
+            rule: '/router/hash',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            location.hash = '/router/hash'
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push('/router/hash/pushok', {
+                foo: 'bar'
+            })
+        }, 100);
+
+        setTimeout(function () {
+            console.log(location.hash);
+            expect(location.hash).toBe('#/router/hash/pushok?foo=bar');
+            expect(location.href.indexOf('#/router/hash/pushok') >= 0).toBeTruthy();
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with object params 2', function(done) {
+        var App = san.defineComponent({
+            template: '<div>something for nothing.</div>'
+        })
+
+        router.setMode('hash');
+
+        router.add({
+            rule: '/router/hash',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            location.hash = '/router/hash'
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/hash/pushok',
+                params: {
+                    foo: 'bar',
+                    bar: null,
+                    far: undefined,
+                }
+            })
+        }, 100);
+
+        setTimeout(function () {
+            expect(location.hash).toBe('#/router/hash/pushok?foo=bar&bar=&far=');
+            expect(location.href.indexOf('#/router/hash/pushok?foo=bar&bar=&far=') >= 0).toBeTruthy();
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with string params', function(done) {
+        var App = san.defineComponent({
+            template: '<div>something for nothing.</div>'
+        })
+
+        router.setMode('hash');
+
+        router.add({
+            rule: '/router/hash',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function (){
+            location.hash = '/router/hash'
+        });
+
+        setTimeout(function () {
+            var $router = router.routeAlives[0].component.$router;
+            $router.push('/router/hash/pushok?foo=bar')
+        }, 100)
+
+        setTimeout(function () {
+            expect(location.hash).toBe('#/router/hash/pushok?foo=bar');
+            expect(location.href.indexOf('#/router/hash/pushok?foo=bar') >= 0).toBeTruthy();
+            router.stop();
+            done();
+        }, 200);
+    })
+
+})
+
+describe('test this.$router.push with html5 history mode', function() {
+
+    it('test this.$router.push with object params', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            router.locator.redirect('/router/html5');
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push('/router/html5/pushok', {
+                foo: 'bar'
+            })
+        }, 100);
+
+        setTimeout(function () {
+            expect(location.pathname).toBe('/router/html5/pushok');
+            expect(location.href.indexOf('/router/html5/pushok') >= 0).toBeTruthy();;
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with object params 2', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            router.locator.redirect('/router/html5');
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/html5/pushok',
+                params: {
+                    foo: 'bar'
+                }
+            })
+        }, 100);
+
+        setTimeout(function () {
+            expect(location.pathname).toBe('/router/html5/pushok');
+            expect(location.href.indexOf('/router/html5/pushok') >= 0).toBeTruthy();;
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with string params', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function (){
+            router.locator.redirect('/router/html5');
+        });
+
+        setTimeout(function () {
+            var $router = router.routeAlives[0].component.$router;
+            $router.push('/router/html5/pushok?foo=bar')
+        }, 100)
+
+        setTimeout(function () {
+            expect(location.pathname).toBe('/router/html5/pushok');
+            expect(location.href.indexOf('/router/html5/pushok') >= 0).toBeTruthy();;
+            router.stop();
+            done();
+        }, 200);
+    })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var HashLocator = sanRouter.HashLocator;
 var HTML5Locator = sanRouter.HTML5Locator;
 
 var parseURL = sanRouter.parseURL;
-var parseParams = sanRouter.parseParams;
+var parseQuery = sanRouter.parseQuery;
 
 
 describe('parseURL', function () {
@@ -39,6 +39,48 @@ describe('parseURL', function () {
         expect(url.query.a[0]).toBe('1');
         expect(url.query.a[1]).toBe('3');
         expect(url.query.name).toBe('2');
+    });
+});
+
+// parseQuery unit test
+describe('parseQuery', function () {
+    it('false invalid value will return empty string :)', function () {
+        var qs = parseQuery('');
+        expect(qs).toBe('');
+        qs = parseQuery(undefined);
+        expect(qs).toBe('');
+        qs = parseQuery(null);
+        expect(qs).toBe('');
+        qs = parseQuery(NaN);
+        expect(qs).toBe('');
+    });
+
+    it('normal case query', function () {
+        var qs = parseQuery({
+            foo: 'bar',
+            bar: 'foo'
+        });
+        expect(qs).toBe('?foo=bar&bar=foo');
+    });
+
+    it('normal case queryString', function () {
+        var qs = parseQuery('?foo=bar&bar=foo');
+        expect(qs).toBe('?foo=bar&bar=foo');
+        qs = parseQuery('foo=bar&bar=foo');
+        expect(qs).toBe('?foo=bar&bar=foo');
+    });
+
+    it('should auto decode query', function () {
+        var qs = parseQuery({
+            foo: '你好',
+            bar: '不好'
+        });
+        expect(qs).toBe('?foo=%E4%BD%A0%E5%A5%BD&bar=%E4%B8%8D%E5%A5%BD');
+    });
+
+    it('unsupport data type will return empty string', function () {
+        var qs = parseQuery(1);
+        expect(qs).toBe('');
     });
 });
 
@@ -280,7 +322,7 @@ var TestComponent = san.defineComponent({
 
 router.add({
     rule: '/main-route/:name',
-    handler: function () {alert('if u see this, it must be an error!')},
+    handler: function () {},
     target: '#main',
     Component: TestComponent
 });
@@ -861,78 +903,6 @@ describe('test this.$router in San component using html5 history', function() {
 
 describe('test this.$router.push with hash mode', function() {
 
-    it('test this.$router.push with object params', function(done) {
-        var App = san.defineComponent({
-            template: '<div>something for nothing.</div>'
-        })
-
-        router.setMode('hash');
-
-        router.add({
-            rule: '/router/hash',
-            Component: App
-        });
-
-        router.start();
-
-        setTimeout(function() {
-            location.hash = '/router/hash'
-        })
-
-        setTimeout(function (){
-            var $router = router.routeAlives[0].component.$router;
-            $router.push('/router/hash/pushok', {
-                foo: 'bar'
-            })
-        }, 100);
-
-        setTimeout(function () {
-            console.log(location.hash);
-            expect(location.hash).toBe('#/router/hash/pushok?foo=bar');
-            expect(location.href.indexOf('#/router/hash/pushok') >= 0).toBeTruthy();
-            router.stop();
-            done();
-        }, 200);
-    })
-
-    it('test this.$router.push with object params 2', function(done) {
-        var App = san.defineComponent({
-            template: '<div>something for nothing.</div>'
-        })
-
-        router.setMode('hash');
-
-        router.add({
-            rule: '/router/hash',
-            Component: App
-        });
-
-        router.start();
-
-        setTimeout(function() {
-            location.hash = '/router/hash'
-        })
-
-        setTimeout(function (){
-            var $router = router.routeAlives[0].component.$router;
-            $router.push({
-                path: '/router/hash/pushok',
-                params: {
-                    foo: 'bar',
-                    bar: null,
-                    far: undefined,
-                }
-            })
-        }, 100);
-
-        setTimeout(function () {
-            expect(location.hash).toBe('#/router/hash/pushok?foo=bar&bar=&far=');
-            expect(location.href.indexOf('#/router/hash/pushok?foo=bar&bar=&far=') >= 0).toBeTruthy();
-            router.stop();
-            done();
-        }, 200);
-    })
-
     it('test this.$router.push with string params', function(done) {
         var App = san.defineComponent({
             template: '<div>something for nothing.</div>'
@@ -954,88 +924,128 @@ describe('test this.$router.push with hash mode', function() {
         setTimeout(function () {
             var $router = router.routeAlives[0].component.$router;
             $router.push('/router/hash/pushok?foo=bar')
-        }, 100)
+        }, 200)
 
         setTimeout(function () {
             expect(location.hash).toBe('#/router/hash/pushok?foo=bar');
             expect(location.href.indexOf('#/router/hash/pushok?foo=bar') >= 0).toBeTruthy();
             router.stop();
             done();
-        }, 200);
+        }, 300);
     })
 
-})
-
-describe('test this.$router.push with html5 history mode', function() {
-
-    it('test this.$router.push with object params', function(done) {
+    it('test this.$router.push with object params case 1', function(done) {
         var App = san.defineComponent({
-            template: '<div>html5 / something for nothing.</div>'
+            template: '<div>something for nothing.</div>'
         })
 
-        router.setMode('html5');
+        router.setMode('hash');
 
         router.add({
-            rule: '/router/html5',
+            rule: '/router/hash',
             Component: App
         });
 
         router.start();
 
         setTimeout(function() {
-            router.locator.redirect('/router/html5');
-        })
-
-        setTimeout(function (){
-            var $router = router.routeAlives[0].component.$router;
-            $router.push('/router/html5/pushok', {
-                foo: 'bar'
-            })
-        }, 100);
-
-        setTimeout(function () {
-            expect(location.pathname).toBe('/router/html5/pushok');
-            expect(location.href.indexOf('/router/html5/pushok') >= 0).toBeTruthy();;
-            router.stop();
-            done();
-        }, 200);
-    })
-
-    it('test this.$router.push with object params 2', function(done) {
-        var App = san.defineComponent({
-            template: '<div>html5 / something for nothing.</div>'
-        })
-
-        router.setMode('html5');
-
-        router.add({
-            rule: '/router/html5',
-            Component: App
-        });
-
-        router.start();
-
-        setTimeout(function() {
-            router.locator.redirect('/router/html5');
+            location.hash = '/router/hash'
         })
 
         setTimeout(function (){
             var $router = router.routeAlives[0].component.$router;
             $router.push({
-                path: '/router/html5/pushok',
-                params: {
+                path: '/router/hash/pushok',
+                query: {
                     foo: 'bar'
                 }
             })
         }, 100);
 
         setTimeout(function () {
-            expect(location.pathname).toBe('/router/html5/pushok');
-            expect(location.href.indexOf('/router/html5/pushok') >= 0).toBeTruthy();;
+            console.log(location.hash);
+            expect(location.hash).toBe('#/router/hash/pushok?foo=bar');
+            expect(location.href.indexOf('#/router/hash/pushok') >= 0).toBeTruthy();
             router.stop();
             done();
         }, 200);
     })
+
+    it('test this.$router.push with object params case 2', function(done) {
+        var App = san.defineComponent({
+            template: '<div>something for nothing.</div>'
+        })
+
+        router.setMode('hash');
+
+        router.add({
+            rule: '/router/hash',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            location.hash = '/router/hash'
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/hash/pushok',
+                queryString: 'foo=bar&bar=foo'
+            })
+        }, 100);
+
+        setTimeout(function () {
+            console.log(location.hash);
+            expect(location.hash).toBe('#/router/hash/pushok?foo=bar&bar=foo');
+            expect(location.href.indexOf('#/router/hash/pushok') >= 0).toBeTruthy();
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with object params case 3', function(done) {
+        var App = san.defineComponent({
+            template: '<div>something for nothing.</div>'
+        })
+
+        router.setMode('hash');
+
+        router.add({
+            rule: '/router/hash',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            location.hash = '/router/hash'
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/hash/pushok',
+                query: {
+                    foo: 'boo'
+                },
+                queryString: 'foo=bar&bar=foo'
+            })
+        }, 100);
+
+        setTimeout(function () {
+            console.log(location.hash);
+            expect(location.hash).toBe('#/router/hash/pushok?foo=bar&bar=foo');
+            expect(location.href.indexOf('#/router/hash/pushok') >= 0).toBeTruthy();
+            router.stop();
+            done();
+        }, 200);
+    })
+})
+
+describe('test this.$router.push with html5 history mode', function() {
 
     it('test this.$router.push with string params', function(done) {
         var App = san.defineComponent({
@@ -1062,8 +1072,152 @@ describe('test this.$router.push with html5 history mode', function() {
 
         setTimeout(function () {
             expect(location.pathname).toBe('/router/html5/pushok');
-            expect(location.href.indexOf('/router/html5/pushok') >= 0).toBeTruthy();;
+            expect(location.href.indexOf('/router/html5/pushok?foo=bar') >= 0).toBeTruthy();;
             router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with object params case 1', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            router.locator.redirect('/router/html5');
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/html5/pushok',
+                query: {
+                    foo: 'bar'
+                }
+            })
+        }, 100);
+
+        setTimeout(function () {
+            expect(location.pathname).toBe('/router/html5/pushok');
+            expect(location.search).toBe('?foo=bar');
+            expect(location.href.indexOf('/router/html5/pushok?foo=bar') >= 0).toBeTruthy();;
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with object params case 2', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            router.locator.redirect('/router/html5');
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/html5/pushok',
+                queryString: 'foo=bar'
+            })
+        }, 100);
+
+        setTimeout(function () {
+            expect(location.pathname).toBe('/router/html5/pushok');
+            expect(location.search).toBe('?foo=bar');
+            expect(location.href.indexOf('/router/html5/pushok?foo=bar') >= 0).toBeTruthy();;
+            router.stop();
+            done();
+        }, 200);
+    })
+
+    it('test this.$router.push with object params case 3', function(done) {
+        var App = san.defineComponent({
+            template: '<div>html5 / something for nothing.</div>'
+        })
+
+        router.setMode('html5');
+
+        router.add({
+            rule: '/router/html5',
+            Component: App
+        });
+
+        router.start();
+
+        setTimeout(function() {
+            router.locator.redirect('/router/html5');
+        })
+
+        setTimeout(function (){
+            var $router = router.routeAlives[0].component.$router;
+            $router.push({
+                path: '/router/html5/pushok',
+                query: {
+                    foo: 'bar'
+                },
+                queryString: 'bar=foo'
+            })
+        }, 100);
+
+        setTimeout(function () {
+            expect(location.pathname).toBe('/router/html5/pushok');
+            expect(location.search).toBe('?bar=foo');
+            expect(location.href.indexOf('/router/html5/pushok?bar=foo') >= 0).toBeTruthy();;
+            router.stop();
+            done();
+        }, 200);
+    })
+})
+
+describe('handler will be trigger whenever Component is defined', function() {
+
+    it('call handler', function(done) {
+        var App = san.defineComponent({
+            template: '<h1>handler / something for nothing.</h1>'
+        })
+
+        router.setMode('hash');
+
+        var ifTrigger = false;
+
+        router.add({
+            rule: '/router/handler',
+            Component: App,
+            handler: function () {
+                ifTrigger = true;
+            }
+        });
+
+        router.start();
+
+        setTimeout(function (){
+            router.locator.redirect('/router/handler');
+        });
+
+        setTimeout(function () {
+            expect(ifTrigger).toBeTruthy();;
+            router.stop();
+            document.getElementById('main').remove();
             done();
         }, 200);
     })


### PR DESCRIPTION
1.实现编程式导航 push 函数
一般项目中使用页面跳转需要直接食用locator，比如：
`router.locator.redirect('/path/to/app' + getParamStrFromObj({ foo: 'bar', bar: 'foo' }));`
个人感觉比较麻烦，所以在router中加了push方法并且在通过router挂载的模版的san中注入路由实例，所以上面的可以变为：
`this.$router.push('path/to/app', { foo: 'bar', bar: 'foo' })`

2.在 san 组件实例中注入 router 路由实例，因此可以在san中直接用 `this.$router` 访问
同上。

2021.7.1 增加了新方法的测试用例